### PR TITLE
docs: add GitHub Action documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ See the [installation docs](https://hone.safia.dev/docs/installation) for more o
 - [Assertions](https://hone.safia.dev/docs/assertions) — All assertion types
 - [Examples](https://hone.safia.dev/examples) — Real-world test examples
 
+## GitHub Actions
+
+Run Hone tests in your CI/CD pipelines with the official GitHub Action:
+
+```yaml
+- uses: captainsafia/hone/hone-github-action@main
+  with:
+    tests: 'tests/*.hone'
+```
+
+See the [GitHub Actions docs](https://hone.safia.dev/docs/github-actions) for more details.
+
 ## Editor Setup
 
 Hone includes a built-in Language Server. Configure your editor automatically:

--- a/site/src/components/Sidebar.astro
+++ b/site/src/components/Sidebar.astro
@@ -11,6 +11,7 @@ const sections = [
     items: [
       { href: '/docs/installation', label: 'Installation' },
       { href: '/docs/getting-started', label: 'Getting Started' },
+      { href: '/docs/github-actions', label: 'GitHub Actions' },
     ]
   },
   {

--- a/site/src/pages/docs/github-actions.astro
+++ b/site/src/pages/docs/github-actions.astro
@@ -1,0 +1,161 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+import CodeBlock from '../../components/CodeBlock.astro';
+
+const basicUsage = `name: Hone Tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Hone tests
+        uses: captainsafia/hone/hone-github-action@main
+        with:
+          tests: 'tests/*.hone'`;
+
+const latestPreview = `- uses: captainsafia/hone/hone-github-action@main
+  with:
+    tests: 'tests/**/*.hone'`;
+
+const pinnedVersion = `- uses: captainsafia/hone/hone-github-action@main
+  with:
+    version: 'v1.2.0'
+    tests: 'tests/integration/api.hone tests/integration/cli.hone'`;
+
+const examplesTests = `- uses: captainsafia/hone/hone-github-action@main
+  with:
+    tests: 'examples/*.hone'`;
+
+const fullExample = `name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      # Build your CLI or application first
+      - name: Build application
+        run: |
+          cargo build --release
+          echo "$PWD/target/release" >> $GITHUB_PATH
+      
+      # Run Hone integration tests
+      - name: Run integration tests
+        uses: captainsafia/hone/hone-github-action@main
+        with:
+          tests: 'tests/**/*.hone'`;
+---
+
+<DocsLayout title="GitHub Actions" currentPath="/docs/github-actions">
+          <h1 class="text-3xl md:text-4xl font-bold mb-8">GitHub Actions</h1>
+          
+          <p class="text-text-muted text-lg mb-8">
+            Run Hone tests in your GitHub Actions CI/CD pipelines with the official Hone GitHub Action.
+          </p>
+          
+          <h2 class="text-2xl font-semibold mt-12 mb-6">Quick Start</h2>
+          <p class="text-text-muted mb-4">
+            Add the Hone GitHub Action to your workflow to automatically run integration tests on every push or pull request:
+          </p>
+          <div class="mb-8">
+            <CodeBlock code={basicUsage} lang="yaml" filename=".github/workflows/test.yml" />
+          </div>
+          
+          <h2 class="text-2xl font-semibold mt-12 mb-6">Inputs</h2>
+          <p class="text-text-muted mb-4">
+            The action accepts the following inputs:
+          </p>
+          
+          <div class="mb-8 overflow-x-auto">
+            <table class="w-full border-collapse text-sm">
+              <thead>
+                <tr class="border-b border-slate/20">
+                  <th class="text-left py-3 px-4 font-semibold">Input</th>
+                  <th class="text-left py-3 px-4 font-semibold">Description</th>
+                  <th class="text-left py-3 px-4 font-semibold">Required</th>
+                  <th class="text-left py-3 px-4 font-semibold">Default</th>
+                </tr>
+              </thead>
+              <tbody class="text-text-muted">
+                <tr class="border-b border-slate/10">
+                  <td class="py-3 px-4"><code class="px-2 py-1 rounded bg-slate/20 dark:bg-slate text-xs font-mono">version</code></td>
+                  <td class="py-3 px-4">Version of Hone to install (e.g., <code class="px-2 py-1 rounded bg-slate/20 dark:bg-slate text-xs font-mono">v1.0.0</code>)</td>
+                  <td class="py-3 px-4">No</td>
+                  <td class="py-3 px-4"><code class="px-2 py-1 rounded bg-slate/20 dark:bg-slate text-xs font-mono">preview</code></td>
+                </tr>
+                <tr class="border-b border-slate/10">
+                  <td class="py-3 px-4"><code class="px-2 py-1 rounded bg-slate/20 dark:bg-slate text-xs font-mono">tests</code></td>
+                  <td class="py-3 px-4">Test files or patterns to run (e.g., <code class="px-2 py-1 rounded bg-slate/20 dark:bg-slate text-xs font-mono">tests/*.hone</code>)</td>
+                  <td class="py-3 px-4">Yes</td>
+                  <td class="py-3 px-4">-</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          
+          <h2 class="text-2xl font-semibold mt-12 mb-6">Examples</h2>
+          
+          <h3 class="text-xl font-semibold mt-8 mb-4">Run all tests with latest preview</h3>
+          <p class="text-text-muted mb-4">
+            By default, the action installs the latest preview release of Hone:
+          </p>
+          <div class="mb-8">
+            <CodeBlock code={latestPreview} lang="yaml" />
+          </div>
+          
+          <h3 class="text-xl font-semibold mt-8 mb-4">Run specific tests with a pinned version</h3>
+          <p class="text-text-muted mb-4">
+            Pin a specific version for reproducible CI builds:
+          </p>
+          <div class="mb-8">
+            <CodeBlock code={pinnedVersion} lang="yaml" />
+          </div>
+          
+          <h3 class="text-xl font-semibold mt-8 mb-4">Run tests from the examples directory</h3>
+          <p class="text-text-muted mb-4">
+            You can run any test files in your repository:
+          </p>
+          <div class="mb-8">
+            <CodeBlock code={examplesTests} lang="yaml" />
+          </div>
+          
+          <h2 class="text-2xl font-semibold mt-12 mb-6">Complete Workflow Example</h2>
+          <p class="text-text-muted mb-4">
+            Here's a complete example that builds an application and runs Hone integration tests:
+          </p>
+          <div class="mb-8">
+            <CodeBlock code={fullExample} lang="yaml" filename=".github/workflows/ci.yml" />
+          </div>
+          
+          <div class="mt-12 p-6 rounded-xl bg-amber/10 border border-amber/20">
+            <h3 class="text-lg font-semibold mb-2 flex items-center gap-2">
+              <svg class="w-5 h-5 text-amber" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              Note
+            </h3>
+            <p class="text-text-muted">
+              Make sure the commands you're testing in your <code class="px-2 py-1 rounded bg-slate/20 dark:bg-slate text-sm font-mono">.hone</code> files are available in your CI environment. You may need to build your application or install dependencies before running the Hone tests.
+            </p>
+          </div>
+          
+          <div class="mt-8 p-6 rounded-xl bg-electric-blue/10 border border-electric-blue/20">
+            <h3 class="text-lg font-semibold mb-2 flex items-center gap-2">
+              <svg class="w-5 h-5 text-electric-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+              </svg>
+              Next Steps
+            </h3>
+            <p class="text-text-muted">
+              Learn more about writing tests in the <a href="/docs/dsl-syntax" class="text-electric-blue hover:underline">DSL Syntax</a> reference, or explore <a href="/examples" class="text-electric-blue hover:underline">example tests</a>.
+            </p>
+          </div>
+</DocsLayout>


### PR DESCRIPTION
Added comprehensive documentation for the new Hone GitHub Action:
- Created new docs page at /docs/github-actions with usage examples
- Added GitHub Actions section to main README
- Updated sidebar navigation to include GitHub Actions link