### PR TITLE
feat: add not contains assertion predicate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -1068,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -1261,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1831,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -1846,15 +1846,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ TEST "echo works"
 RUN echo "Hello, World!"
 ASSERT exit_code == 0
 ASSERT stdout contains "Hello"
+ASSERT stdout not contains "Goodbye"
 
 TEST "file creation"
 
 RUN echo "test content" > output.txt
 ASSERT file "output.txt" exists
 ASSERT file "output.txt" contains "test content"
+ASSERT file "output.txt" not contains "error"
 ```
 
 Run the tests:

--- a/examples/assertions.hone
+++ b/examples/assertions.hone
@@ -8,6 +8,7 @@ RUN echo "Hello, World!"
 ASSERT stdout contains "Hello"
 ASSERT stdout contains "World"
 ASSERT stdout contains ","
+ASSERT stdout not contains "Goodbye"
 
 TEST "stdout equals assertion"
 
@@ -45,6 +46,7 @@ TEST "stderr capture"
 
 RUN sh -c 'echo "error message" >&2'
 ASSERT stderr contains "error message"
+ASSERT stderr not contains "success"
 
 TEST "named run targets"
 

--- a/examples/filesystem.hone
+++ b/examples/filesystem.hone
@@ -13,6 +13,7 @@ RUN echo "test content here" > /tmp/hone-test-content.txt
 ASSERT file "/tmp/hone-test-content.txt" exists
 ASSERT file "/tmp/hone-test-content.txt" contains "test content"
 ASSERT file "/tmp/hone-test-content.txt" contains "here"
+ASSERT file "/tmp/hone-test-content.txt" not contains "missing"
 
 TEST "file exact match"
 

--- a/src/assertions/filesystem.rs
+++ b/src/assertions/filesystem.rs
@@ -1,5 +1,7 @@
 use crate::assertions::AssertionResult;
-use crate::parser::ast::{FilePredicate, RegexLiteral, StringComparisonOperator, StringLiteral};
+use crate::parser::ast::{
+    FilePredicate, RegexLiteral, StringComparisonOperator, StringContainmentOperator, StringLiteral,
+};
 use std::path::{Path, PathBuf};
 
 struct FileExistsResult {
@@ -17,8 +19,8 @@ pub async fn evaluate_file_predicate(
 
     match predicate {
         FilePredicate::Exists => evaluate_file_exists(&resolved_path, &file_path.raw, cwd).await,
-        FilePredicate::Contains { value } => {
-            evaluate_file_contains(&resolved_path, value, &file_path.raw, cwd).await
+        FilePredicate::Contains { operator, value } => {
+            evaluate_file_contains(&resolved_path, operator, value, &file_path.raw, cwd).await
         }
         FilePredicate::Matches { value } => {
             evaluate_file_matches(&resolved_path, value, &file_path.raw, cwd).await
@@ -142,6 +144,7 @@ async fn read_file_content(
 
 async fn evaluate_file_contains(
     file_path: &Path,
+    operator: &StringContainmentOperator,
     value: &StringLiteral,
     path_raw: &str,
     cwd: &str,
@@ -151,12 +154,19 @@ async fn evaluate_file_contains(
         return err;
     }
 
-    let passed = content.contains(&value.value);
-    AssertionResult::new(
-        passed,
-        format!("file {} to contain {}", path_raw, value.raw),
-        content,
-    )
+    let contains = content.contains(&value.value);
+    let (passed, expected) = match operator {
+        StringContainmentOperator::Contains => (
+            contains,
+            format!("file {} to contain {}", path_raw, value.raw),
+        ),
+        StringContainmentOperator::NotContains => (
+            !contains,
+            format!("file {} not to contain {}", path_raw, value.raw),
+        ),
+    };
+
+    AssertionResult::new(passed, expected, content)
 }
 
 async fn evaluate_file_matches(
@@ -340,7 +350,10 @@ mod tests {
         let search = make_string_literal("world");
         let result = evaluate_file_predicate(
             &path,
-            &FilePredicate::Contains { value: search },
+            &FilePredicate::Contains {
+                operator: StringContainmentOperator::Contains,
+                value: search,
+            },
             temp_dir.to_str().unwrap(),
         )
         .await;
@@ -360,7 +373,10 @@ mod tests {
         let search = make_string_literal("goodbye");
         let result = evaluate_file_predicate(
             &path,
-            &FilePredicate::Contains { value: search },
+            &FilePredicate::Contains {
+                operator: StringContainmentOperator::Contains,
+                value: search,
+            },
             temp_dir.to_str().unwrap(),
         )
         .await;
@@ -374,12 +390,68 @@ mod tests {
     async fn test_evaluate_file_contains_nonexistent() {
         let path = make_string_literal("nonexistent_file.txt");
         let search = make_string_literal("test");
-        let result =
-            evaluate_file_predicate(&path, &FilePredicate::Contains { value: search }, "/tmp")
-                .await;
+        let result = evaluate_file_predicate(
+            &path,
+            &FilePredicate::Contains {
+                operator: StringContainmentOperator::Contains,
+                value: search,
+            },
+            "/tmp",
+        )
+        .await;
 
         assert!(!result.passed);
         assert!(result.actual.contains("does not exist"));
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_file_not_contains_match() {
+        let temp_dir = std::env::temp_dir();
+        let temp_file = temp_dir.join("hone_test_not_contains.txt");
+        tokio::fs::write(&temp_file, "hello world").await.unwrap();
+
+        let path = make_string_literal(temp_file.file_name().unwrap().to_str().unwrap());
+        let search = make_string_literal("goodbye");
+        let result = evaluate_file_predicate(
+            &path,
+            &FilePredicate::Contains {
+                operator: StringContainmentOperator::NotContains,
+                value: search,
+            },
+            temp_dir.to_str().unwrap(),
+        )
+        .await;
+
+        let _ = tokio::fs::remove_file(&temp_file).await;
+
+        assert!(result.passed);
+        assert_eq!(
+            result.expected,
+            format!("file {} not to contain \"goodbye\"", path.raw)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_file_not_contains_no_match() {
+        let temp_dir = std::env::temp_dir();
+        let temp_file = temp_dir.join("hone_test_not_contains_no.txt");
+        tokio::fs::write(&temp_file, "hello world").await.unwrap();
+
+        let path = make_string_literal(temp_file.file_name().unwrap().to_str().unwrap());
+        let search = make_string_literal("hello");
+        let result = evaluate_file_predicate(
+            &path,
+            &FilePredicate::Contains {
+                operator: StringContainmentOperator::NotContains,
+                value: search,
+            },
+            temp_dir.to_str().unwrap(),
+        )
+        .await;
+
+        let _ = tokio::fs::remove_file(&temp_file).await;
+
+        assert!(!result.passed);
     }
 
     #[tokio::test]
@@ -516,7 +588,10 @@ mod tests {
         let search = make_string_literal("test");
         let result = evaluate_file_predicate(
             &path,
-            &FilePredicate::Contains { value: search },
+            &FilePredicate::Contains {
+                operator: StringContainmentOperator::Contains,
+                value: search,
+            },
             temp_dir.to_str().unwrap(),
         )
         .await;

--- a/src/assertions/output.rs
+++ b/src/assertions/output.rs
@@ -1,6 +1,7 @@
 use crate::assertions::AssertionResult;
 use crate::parser::ast::{
-    OutputPredicate, OutputSelector, RegexLiteral, StringComparisonOperator, StringLiteral,
+    OutputPredicate, OutputSelector, RegexLiteral, StringComparisonOperator,
+    StringContainmentOperator, StringLiteral,
 };
 use crate::runner::shell::RunResult;
 
@@ -14,19 +15,26 @@ pub fn get_output_value<'a>(result: &'a RunResult, selector: &OutputSelector) ->
 
 pub fn evaluate_output_predicate(output: &str, predicate: &OutputPredicate) -> AssertionResult {
     match predicate {
-        OutputPredicate::Contains { value } => evaluate_contains(output, value),
+        OutputPredicate::Contains { operator, value } => evaluate_contains(output, operator, value),
         OutputPredicate::Matches { value } => evaluate_matches(output, value),
         OutputPredicate::Equals { operator, value } => evaluate_equals(output, operator, value),
     }
 }
 
-fn evaluate_contains(output: &str, value: &StringLiteral) -> AssertionResult {
-    let passed = output.contains(&value.value);
-    AssertionResult::new(
-        passed,
-        format!("to contain {}", value.raw),
-        output.to_string(),
-    )
+fn evaluate_contains(
+    output: &str,
+    operator: &StringContainmentOperator,
+    value: &StringLiteral,
+) -> AssertionResult {
+    let contains = output.contains(&value.value);
+    let (passed, expected) = match operator {
+        StringContainmentOperator::Contains => (contains, format!("to contain {}", value.raw)),
+        StringContainmentOperator::NotContains => {
+            (!contains, format!("not to contain {}", value.raw))
+        }
+    };
+
+    AssertionResult::new(passed, expected, output.to_string())
 }
 
 fn evaluate_matches(output: &str, value: &RegexLiteral) -> AssertionResult {
@@ -93,7 +101,7 @@ fn normalize_whitespace(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::ast::{QuoteType, RegexLiteral, StringLiteral};
+    use crate::parser::ast::{QuoteType, RegexLiteral, StringContainmentOperator, StringLiteral};
     use crate::runner::shell::RunResult;
 
     #[test]
@@ -144,8 +152,9 @@ mod tests {
             raw: "\"hello\"".to_string(),
             quote_type: QuoteType::Double,
         };
-        let result = evaluate_contains("hello world", &value);
+        let result = evaluate_contains("hello world", &StringContainmentOperator::Contains, &value);
         assert!(result.passed);
+        assert_eq!(result.expected, "to contain \"hello\"");
     }
 
     #[test]
@@ -155,7 +164,7 @@ mod tests {
             raw: "\"goodbye\"".to_string(),
             quote_type: QuoteType::Double,
         };
-        let result = evaluate_contains("hello world", &value);
+        let result = evaluate_contains("hello world", &StringContainmentOperator::Contains, &value);
         assert!(!result.passed);
     }
 
@@ -166,7 +175,38 @@ mod tests {
             raw: "\"test\"".to_string(),
             quote_type: QuoteType::Double,
         };
-        let result = evaluate_contains("", &value);
+        let result = evaluate_contains("", &StringContainmentOperator::Contains, &value);
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn test_evaluate_not_contains_match() {
+        let value = StringLiteral {
+            value: "goodbye".to_string(),
+            raw: "\"goodbye\"".to_string(),
+            quote_type: QuoteType::Double,
+        };
+        let result = evaluate_contains(
+            "hello world",
+            &StringContainmentOperator::NotContains,
+            &value,
+        );
+        assert!(result.passed);
+        assert_eq!(result.expected, "not to contain \"goodbye\"");
+    }
+
+    #[test]
+    fn test_evaluate_not_contains_no_match() {
+        let value = StringLiteral {
+            value: "hello".to_string(),
+            raw: "\"hello\"".to_string(),
+            quote_type: QuoteType::Double,
+        };
+        let result = evaluate_contains(
+            "hello world",
+            &StringContainmentOperator::NotContains,
+            &value,
+        );
         assert!(!result.passed);
     }
 

--- a/src/lsp/completion.rs
+++ b/src/lsp/completion.rs
@@ -207,7 +207,9 @@ impl CompletionProvider {
                 documentation: Some(async_lsp::lsp_types::Documentation::String(
                     "Check the standard output of the command".to_string(),
                 )),
-                insert_text: Some("stdout ${1|contains,==,!=,matches|} \"${2:text}\"".to_string()),
+                insert_text: Some(
+                    "stdout ${1|contains,not contains,==,!=,matches|} \"${2:text}\"".to_string(),
+                ),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 ..Default::default()
             },
@@ -218,7 +220,9 @@ impl CompletionProvider {
                 documentation: Some(async_lsp::lsp_types::Documentation::String(
                     "Check the standard error of the command".to_string(),
                 )),
-                insert_text: Some("stderr ${1|contains,==,!=,matches|} \"${2:text}\"".to_string()),
+                insert_text: Some(
+                    "stderr ${1|contains,not contains,==,!=,matches|} \"${2:text}\"".to_string(),
+                ),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 ..Default::default()
             },
@@ -241,7 +245,8 @@ impl CompletionProvider {
                     "Check the contents of a file".to_string(),
                 )),
                 insert_text: Some(
-                    "file \"${1:path}\" ${2|contains,==,!=,matches,exists|}".to_string(),
+                    "file \"${1:path}\" ${2|contains,not contains,==,!=,matches,exists|}"
+                        .to_string(),
                 ),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 ..Default::default()
@@ -537,13 +542,13 @@ mod tests {
         let stdout = items.iter().find(|i| i.label == "stdout").unwrap();
         assert_eq!(
             stdout.insert_text.as_ref().unwrap(),
-            "stdout ${1|contains,==,!=,matches|} \"${2:text}\""
+            "stdout ${1|contains,not contains,==,!=,matches|} \"${2:text}\""
         );
 
         let stderr = items.iter().find(|i| i.label == "stderr").unwrap();
         assert_eq!(
             stderr.insert_text.as_ref().unwrap(),
-            "stderr ${1|contains,==,!=,matches|} \"${2:text}\""
+            "stderr ${1|contains,not contains,==,!=,matches|} \"${2:text}\""
         );
     }
 
@@ -582,7 +587,7 @@ mod tests {
         let insert_text = file.insert_text.as_ref().unwrap();
         assert_eq!(
             insert_text,
-            "file \"${1:path}\" ${2|contains,==,!=,matches,exists|}"
+            "file \"${1:path}\" ${2|contains,not contains,==,!=,matches,exists|}"
         );
         // Should not have block syntax (newlines or nested braces for file content)
         assert!(!insert_text.contains('\n'));

--- a/src/lsp/diagnostics.rs
+++ b/src/lsp/diagnostics.rs
@@ -1,6 +1,6 @@
 use crate::parser::{
     parse_file, ASTNode, AssertionExpression, ComparisonOperator, FilePredicate, OutputPredicate,
-    ParseResult,
+    ParseResult, StringContainmentOperator,
 };
 use async_lsp::lsp_types::*;
 
@@ -252,12 +252,19 @@ fn check_assertion_types(assert_node: &crate::parser::AssertNode) -> Vec<Diagnos
 
     match &assert_node.expression {
         AssertionExpression::Output { predicate, .. } => match predicate {
-            OutputPredicate::Contains { value } => {
+            OutputPredicate::Contains { operator, value } => {
                 // `contains ""` is nonsensical - every string contains empty string
                 if value.value.is_empty() {
+                    let predicate_name = match operator {
+                        StringContainmentOperator::Contains => "contains",
+                        StringContainmentOperator::NotContains => "not contains",
+                    };
                     diagnostics.push(create_semantic_diagnostic(
                         assert_node.line,
-                        "String comparison value cannot be empty for 'contains'",
+                        &format!(
+                            "String comparison value cannot be empty for '{}'",
+                            predicate_name
+                        ),
                     ));
                 }
             }
@@ -330,12 +337,19 @@ fn check_assertion_types(assert_node: &crate::parser::AssertNode) -> Vec<Diagnos
             }
 
             match predicate {
-                FilePredicate::Contains { value } => {
+                FilePredicate::Contains { operator, value } => {
                     // `contains ""` is nonsensical - every string contains empty string
                     if value.value.is_empty() {
+                        let predicate_name = match operator {
+                            StringContainmentOperator::Contains => "contains",
+                            StringContainmentOperator::NotContains => "not contains",
+                        };
                         diagnostics.push(create_semantic_diagnostic(
                             assert_node.line,
-                            "String comparison value cannot be empty for 'contains'",
+                            &format!(
+                                "String comparison value cannot be empty for '{}'",
+                                predicate_name
+                            ),
                         ));
                     }
                 }
@@ -718,6 +732,44 @@ ASSERT file "test.txt" contains """#;
             empty_errors.len(),
             1,
             "ASSERT file \"x\" contains \"\" should produce a diagnostic"
+        );
+    }
+
+    #[test]
+    fn test_empty_string_not_contains_is_invalid() {
+        let content = r#"TEST "empty not contains check"
+RUN true
+ASSERT stdout not contains """#;
+
+        let diagnostics = generate_diagnostics(&Url::parse("file:///test.hone").unwrap(), content);
+
+        let empty_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("not contains"))
+            .collect();
+        assert_eq!(
+            empty_errors.len(),
+            1,
+            "ASSERT stdout not contains \"\" should produce a diagnostic"
+        );
+    }
+
+    #[test]
+    fn test_file_empty_string_not_contains_is_invalid() {
+        let content = r#"TEST "empty file not contains check"
+RUN true
+ASSERT file "test.txt" not contains """#;
+
+        let diagnostics = generate_diagnostics(&Url::parse("file:///test.hone").unwrap(), content);
+
+        let empty_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("not contains"))
+            .collect();
+        assert_eq!(
+            empty_errors.len(),
+            1,
+            "ASSERT file \"x\" not contains \"\" should produce a diagnostic"
         );
     }
 

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -180,6 +180,7 @@ Assert on standard output content.
 ## Predicates
 
 - `contains "text"` - Output contains the text
+- `not contains "text"` - Output does not contain the text
 - `matches /regex/` - Output matches the regex pattern
 - `equals "text"` or `== "text"` - Output equals the text exactly
 - `!= "text"` - Output does not equal the text
@@ -207,6 +208,7 @@ Assert on raw standard output content (without ANSI escape sequences stripped).
 
 Same as `stdout`:
 - `contains "text"`
+- `not contains "text"`
 - `matches /regex/`
 - `equals "text"` or `== "text"`
 - `!= "text"`
@@ -230,6 +232,7 @@ Assert on standard error content.
 ## Predicates
 
 - `contains "text"` - Error output contains the text
+- `not contains "text"` - Error output does not contain the text
 - `matches /regex/` - Error output matches the regex pattern
 - `equals "text"` or `== "text"` - Error output equals the text exactly
 - `!= "text"` - Error output does not equal the text
@@ -319,6 +322,7 @@ Assert on file content or existence.
 
 - `exists` - File exists
 - `contains "text"` - File contains the text
+- `not contains "text"` - File does not contain the text
 - `matches /regex/` - File content matches the regex pattern
 - `equals "text"` or `== "text"` - File content equals the text exactly
 - `!= "text"` - File content does not equal the text

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -201,7 +201,10 @@ fn extract_assertion_name(assert: &crate::parser::ast::AssertNode) -> String {
             };
 
             let predicate_str = match predicate {
-                crate::parser::ast::OutputPredicate::Contains { .. } => "contains",
+                crate::parser::ast::OutputPredicate::Contains { operator, .. } => match operator {
+                    crate::parser::ast::StringContainmentOperator::Contains => "contains",
+                    crate::parser::ast::StringContainmentOperator::NotContains => "not contains",
+                },
                 crate::parser::ast::OutputPredicate::Matches { .. } => "matches",
                 crate::parser::ast::OutputPredicate::Equals { .. } => "equals",
             };
@@ -297,6 +300,44 @@ mod tests {
         assert_eq!(children.len(), 1);
         assert_eq!(children[0].name, "expect exitcode");
         assert_eq!(children[0].kind, SymbolKind::PROPERTY);
+    }
+
+    #[test]
+    fn test_symbols_with_not_contains_assertion() {
+        let parsed = ParsedFile {
+            filename: "test.hone".to_string(),
+            pragmas: vec![],
+            nodes: vec![
+                ASTNode::Test(TestNode {
+                    name: "my test".to_string(),
+                    line: 1,
+                }),
+                ASTNode::Assert(AssertNode {
+                    expression: AssertionExpression::Output {
+                        target: None,
+                        selector: OutputSelector::Stdout,
+                        predicate: OutputPredicate::Contains {
+                            operator: StringContainmentOperator::NotContains,
+                            value: StringLiteral {
+                                value: "oops".to_string(),
+                                raw: "\"oops\"".to_string(),
+                                quote_type: QuoteType::Double,
+                            },
+                        },
+                    },
+                    line: 2,
+                    raw: "ASSERT stdout not contains \"oops\"".to_string(),
+                }),
+            ],
+            warnings: vec![],
+            errors: vec![],
+        };
+
+        let provider = SymbolsProvider::new();
+        let symbols = provider.provide_symbols(&parsed);
+        let children = symbols[0].children.as_ref().unwrap();
+
+        assert_eq!(children[0].name, "expect stdout not contains");
     }
 
     #[test]

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -96,8 +96,15 @@ pub enum StringComparisonOperator {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum StringContainmentOperator {
+    Contains,
+    NotContains,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum OutputPredicate {
     Contains {
+        operator: StringContainmentOperator,
         value: StringLiteral,
     },
     Matches {
@@ -125,6 +132,7 @@ pub struct DurationPredicate {
 pub enum FilePredicate {
     Exists,
     Contains {
+        operator: StringContainmentOperator,
         value: StringLiteral,
     },
     Matches {

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -497,7 +497,40 @@ fn parse_output_assertion(
         return Some(AssertionExpression::Output {
             target,
             selector,
-            predicate: OutputPredicate::Contains { value: string_lit },
+            predicate: OutputPredicate::Contains {
+                operator: StringContainmentOperator::Contains,
+                value: string_lit,
+            },
+        });
+    }
+
+    if match_word(input, i, "not") {
+        i += 3;
+        i = skip_whitespace(input, i);
+
+        if !match_word(input, i, "contains") {
+            collector.add_error("Expected \"contains\" after \"not\"".to_string(), line);
+            return None;
+        }
+
+        i += 8;
+        i = skip_whitespace(input, i);
+
+        let Some((string_lit, _)) = parse_string_literal(input, i) else {
+            collector.add_error(
+                "Expected quoted string after \"not contains\"".to_string(),
+                line,
+            );
+            return None;
+        };
+
+        return Some(AssertionExpression::Output {
+            target,
+            selector,
+            predicate: OutputPredicate::Contains {
+                operator: StringContainmentOperator::NotContains,
+                value: string_lit,
+            },
         });
     }
 
@@ -555,7 +588,7 @@ fn parse_output_assertion(
 
     collector.add_error(
         format!(
-            "Expected predicate (contains, matches, ==, !=) after \"{}\"",
+            "Expected predicate (contains, not contains, matches, ==, !=) after \"{}\"",
             selector_str
         ),
         line,
@@ -682,7 +715,39 @@ fn parse_file_assertion(
 
         return Some(AssertionExpression::File {
             path,
-            predicate: FilePredicate::Contains { value: string_lit },
+            predicate: FilePredicate::Contains {
+                operator: StringContainmentOperator::Contains,
+                value: string_lit,
+            },
+        });
+    }
+
+    if match_word(input, i, "not") {
+        i += 3;
+        i = skip_whitespace(input, i);
+
+        if !match_word(input, i, "contains") {
+            collector.add_error("Expected \"contains\" after \"not\"".to_string(), line);
+            return None;
+        }
+
+        i += 8;
+        i = skip_whitespace(input, i);
+
+        let Some((string_lit, _)) = parse_string_literal(input, i) else {
+            collector.add_error(
+                "Expected quoted string after \"not contains\"".to_string(),
+                line,
+            );
+            return None;
+        };
+
+        return Some(AssertionExpression::File {
+            path,
+            predicate: FilePredicate::Contains {
+                operator: StringContainmentOperator::NotContains,
+                value: string_lit,
+            },
         });
     }
 
@@ -731,7 +796,8 @@ fn parse_file_assertion(
     }
 
     collector.add_error(
-        "Expected predicate (exists, contains, matches, ==, !=) after file path".to_string(),
+        "Expected predicate (exists, contains, not contains, matches, ==, !=) after file path"
+            .to_string(),
         line,
     );
     None
@@ -1180,7 +1246,7 @@ ASSERT exit_code {} 0"#,
 
     #[test]
     fn test_stdout_rejects_relational_operators() {
-        // stdout only supports ==, !=, contains, matches - not <, <=, >, >=
+        // stdout only supports ==, !=, contains, not contains, matches - not <, <=, >, >=
         let operators = ["<", "<=", ">", ">="];
         for op in operators {
             let content = format!(
@@ -1199,9 +1265,9 @@ ASSERT stdout {} "hello""#,
                         op
                     );
                     assert!(
-                        file.errors
-                            .iter()
-                            .any(|e| e.message.contains("contains, matches, ==, !=")),
+                        file.errors.iter().any(|e| e
+                            .message
+                            .contains("contains, not contains, matches, ==, !=")),
                         "Error message should indicate valid predicates for operator {}",
                         op
                     );
@@ -1215,7 +1281,7 @@ ASSERT stdout {} "hello""#,
 
     #[test]
     fn test_stderr_rejects_relational_operators() {
-        // stderr only supports ==, !=, contains, matches - not <, <=, >, >=
+        // stderr only supports ==, !=, contains, not contains, matches - not <, <=, >, >=
         let operators = ["<", "<=", ">", ">="];
         for op in operators {
             let content = format!(
@@ -1234,9 +1300,9 @@ ASSERT stderr {} "hello""#,
                         op
                     );
                     assert!(
-                        file.errors
-                            .iter()
-                            .any(|e| e.message.contains("contains, matches, ==, !=")),
+                        file.errors.iter().any(|e| e
+                            .message
+                            .contains("contains, not contains, matches, ==, !=")),
                         "Error message should indicate valid predicates for operator {}",
                         op
                     );
@@ -1733,6 +1799,96 @@ ASSERT stdout contains"#;
     }
 
     #[test]
+    fn test_output_not_contains_parses() {
+        let content = r#"TEST "not contains"
+RUN echo hello
+ASSERT stdout not contains "goodbye""#;
+        let result = parse_file(content, "test.hone");
+
+        match result {
+            ParseResult::Success { file } => {
+                assert!(file.errors.is_empty(), "Expected no errors");
+                let assert_nodes: Vec<_> = file
+                    .nodes
+                    .iter()
+                    .filter_map(|n| {
+                        if let ASTNode::Assert(a) = n {
+                            Some(a)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                if let AssertionExpression::Output {
+                    predicate:
+                        OutputPredicate::Contains {
+                            operator: StringContainmentOperator::NotContains,
+                            value,
+                        },
+                    ..
+                } = &assert_nodes[0].expression
+                {
+                    assert_eq!(value.value, "goodbye");
+                } else {
+                    panic!("Expected stdout not contains assertion expression");
+                }
+            }
+            ParseResult::Failure { .. } => {
+                panic!("Parser should always return Success");
+            }
+        }
+    }
+
+    #[test]
+    fn test_output_not_contains_missing_contains_error() {
+        let content = r#"TEST "missing contains"
+RUN echo hello
+ASSERT stdout not foo"#;
+        let result = parse_file(content, "test.hone");
+
+        match result {
+            ParseResult::Success { file } => {
+                assert!(
+                    !file.errors.is_empty(),
+                    "Expected error for invalid predicate after 'not'"
+                );
+                assert_eq!(
+                    file.errors[0].message,
+                    "Expected \"contains\" after \"not\""
+                );
+            }
+            ParseResult::Failure { .. } => {
+                panic!("Parser should always return Success with errors embedded");
+            }
+        }
+    }
+
+    #[test]
+    fn test_output_not_contains_missing_string_error() {
+        let content = r#"TEST "missing string"
+RUN echo hello
+ASSERT stdout not contains"#;
+        let result = parse_file(content, "test.hone");
+
+        match result {
+            ParseResult::Success { file } => {
+                assert!(
+                    !file.errors.is_empty(),
+                    "Expected error for missing string after 'not contains'"
+                );
+                assert_eq!(
+                    file.errors[0].message,
+                    "Expected quoted string after \"not contains\""
+                );
+            }
+            ParseResult::Failure { .. } => {
+                panic!("Parser should always return Success with errors embedded");
+            }
+        }
+    }
+
+    #[test]
     fn test_output_matches_missing_regex_error() {
         // stdout matches without regex should produce a clear error
         let content = r#"TEST "missing regex"
@@ -1841,6 +1997,54 @@ ASSERT file "test.txt" contains"#;
     }
 
     #[test]
+    fn test_file_not_contains_missing_contains_error() {
+        let content = r#"TEST "missing contains"
+RUN echo hello > test.txt
+ASSERT file "test.txt" not foo"#;
+        let result = parse_file(content, "test.hone");
+
+        match result {
+            ParseResult::Success { file } => {
+                assert!(
+                    !file.errors.is_empty(),
+                    "Expected error for invalid file predicate after 'not'"
+                );
+                assert_eq!(
+                    file.errors[0].message,
+                    "Expected \"contains\" after \"not\""
+                );
+            }
+            ParseResult::Failure { .. } => {
+                panic!("Parser should always return Success with errors embedded");
+            }
+        }
+    }
+
+    #[test]
+    fn test_file_not_contains_missing_string_error() {
+        let content = r#"TEST "missing string"
+RUN echo hello > test.txt
+ASSERT file "test.txt" not contains"#;
+        let result = parse_file(content, "test.hone");
+
+        match result {
+            ParseResult::Success { file } => {
+                assert!(
+                    !file.errors.is_empty(),
+                    "Expected error for missing string after file not contains"
+                );
+                assert_eq!(
+                    file.errors[0].message,
+                    "Expected quoted string after \"not contains\""
+                );
+            }
+            ParseResult::Failure { .. } => {
+                panic!("Parser should always return Success with errors embedded");
+            }
+        }
+    }
+
+    #[test]
     fn test_file_matches_missing_regex_error() {
         // file matches without regex should produce a clear error
         let content = r#"TEST "missing regex"
@@ -1898,6 +2102,52 @@ ASSERT build.stdout contains "hello""#;
                     assert!(matches!(selector, OutputSelector::Stdout));
                 } else {
                     panic!("Expected Output assertion expression");
+                }
+            }
+            ParseResult::Failure { .. } => {
+                panic!("Parser should always return Success");
+            }
+        }
+    }
+
+    #[test]
+    fn test_named_target_assertion_stdout_not_contains() {
+        let content = r#"TEST "named target"
+RUN build: echo "hello"
+ASSERT build.stdout not contains "goodbye""#;
+        let result = parse_file(content, "test.hone");
+
+        match result {
+            ParseResult::Success { file } => {
+                assert!(file.errors.is_empty(), "Expected no errors");
+                let assert_nodes: Vec<_> = file
+                    .nodes
+                    .iter()
+                    .filter_map(|n| {
+                        if let ASTNode::Assert(a) = n {
+                            Some(a)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                assert_eq!(assert_nodes.len(), 1);
+
+                if let AssertionExpression::Output {
+                    target,
+                    selector,
+                    predicate:
+                        OutputPredicate::Contains {
+                            operator: StringContainmentOperator::NotContains,
+                            value,
+                        },
+                } = &assert_nodes[0].expression
+                {
+                    assert_eq!(target.as_deref(), Some("build"));
+                    assert!(matches!(selector, OutputSelector::Stdout));
+                    assert_eq!(value.value, "goodbye");
+                } else {
+                    panic!("Expected Output not contains assertion expression");
                 }
             }
             ParseResult::Failure { .. } => {
@@ -1971,6 +2221,50 @@ ASSERT my-build.stdout contains "test""#;
                     assert_eq!(target.as_deref(), Some("my-build"));
                 } else {
                     panic!("Expected Output assertion expression");
+                }
+            }
+            ParseResult::Failure { .. } => {
+                panic!("Parser should always return Success");
+            }
+        }
+    }
+
+    #[test]
+    fn test_file_assertion_not_contains() {
+        let content = r#"TEST "file predicate"
+RUN echo "hello" > test.txt
+ASSERT file "test.txt" not contains "goodbye""#;
+        let result = parse_file(content, "test.hone");
+
+        match result {
+            ParseResult::Success { file } => {
+                assert!(file.errors.is_empty(), "Expected no errors");
+                let assert_nodes: Vec<_> = file
+                    .nodes
+                    .iter()
+                    .filter_map(|n| {
+                        if let ASTNode::Assert(a) = n {
+                            Some(a)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                assert_eq!(assert_nodes.len(), 1);
+
+                if let AssertionExpression::File {
+                    path,
+                    predicate:
+                        FilePredicate::Contains {
+                            operator: StringContainmentOperator::NotContains,
+                            value,
+                        },
+                } = &assert_nodes[0].expression
+                {
+                    assert_eq!(path.value, "test.txt");
+                    assert_eq!(value.value, "goodbye");
+                } else {
+                    panic!("Expected File not contains assertion expression");
                 }
             }
             ParseResult::Failure { .. } => {

--- a/tests/integration/file-assertions.hone
+++ b/tests/integration/file-assertions.hone
@@ -7,6 +7,7 @@ ASSERT file "testfile.txt" exists
 TEST "file content check"
 RUN echo "test content" > contentfile.txt
 ASSERT file "contentfile.txt" contains "test content"
+ASSERT file "contentfile.txt" not contains "goodbye"
 
 TEST "file exact content"
 RUN printf "exact" > exactfile.txt

--- a/tests/integration/regex-matching.hone
+++ b/tests/integration/regex-matching.hone
@@ -11,6 +11,7 @@ ASSERT stdout matches /test\.string/
 TEST "string contains"
 RUN echo "Hello World"
 ASSERT stdout contains "World"
+ASSERT stdout not contains "Goodbye"
 
 TEST "string exact equals"
 RUN echo "exact"


### PR DESCRIPTION
## Summary
- add not contains as a first-class assertion predicate for output and file assertions
- wire the new predicate through parser, runtime evaluation, LSP completions/diagnostics/symbols, and docs/examples
- add parser, runtime, LSP, and integration coverage for the new syntax and validation cases

## Testing
- cargo test
- cargo run --release -- tests/integration/*.hone
- cargo clippy
- cargo fmt --check