### PR TITLE
ci: add macOS matrix and enforce dependency audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@ permissions:
 jobs:
   quality:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,7 +68,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: hone-ubuntu-latest
+          name: hone-${{ matrix.os }}
           path: target/release/hone
 
   security:
@@ -78,11 +82,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Install cargo-outdated
+        run: cargo install cargo-outdated --locked
 
       - name: Run security audit
         run: cargo audit
 
       - name: Check for outdated dependencies
-        run: cargo outdated --exit-code 0 || true
+        run: cargo outdated --exit-code 0
         continue-on-error: true


### PR DESCRIPTION
## Summary

- Convert the `quality` job to a matrix over `ubuntu-latest` and `macos-latest` with `fail-fast: false`, so build/test/integration/example suites run on both OSes. Existing cache keys keep `${{ runner.os }}` so Linux and macOS caches stay isolated, and the uploaded artifact is now suffixed with the matrix OS (`hone-${{ matrix.os }}`).
- Tighten the `security` job: remove the trailing `|| true` from the `cargo outdated` step so its exit code is meaningful, but keep `continue-on-error: true` so outdated remains informational (chose the "keep outdated informational" option from the task).
- Pin both audit tools for reproducibility: `cargo install cargo-audit --locked` and add an explicit `cargo install cargo-outdated --locked` step (the previous workflow assumed `cargo-outdated` was preinstalled on the runner).
- Scope is strictly `.github/workflows/ci.yml`; `release.yml` and `update-docs.yml` are untouched.

## Verification

- Parsed the updated workflow with PyYAML to confirm valid syntax and the expected structure (matrix, artifact name, security steps). `yamllint` was not available in the sandbox.
- Skipped `cargo` checks: this PR touches no Rust source. (Note: the sandbox's stable Cargo 1.83.0 also can't resolve the full dependency tree because a transitive dep requires `edition2024`, so a `cargo` invocation would not have been meaningful even if attempted.)
- Actual CI behavior will be validated when this PR runs on GitHub Actions.

_Conversation: https://app.warp.dev/conversation/76775830-fa32-4771-addf-7978dbfbde92_

_This PR was generated with [Oz](https://warp.dev/oz)._
