### PR TITLE
docs: add CHANGELOG, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-05-18
+
+### Added
+
+- DSL parser with line- and column-aware diagnostics.
+- Test runner backed by a sentinel-protocol shell session for accurate
+  command boundary and exit-code tracking.
+- Assertion suite covering `stdout`, `stderr`, `exit_code`, `duration`,
+  and `file` checks.
+- Language Server (LSP) implementation providing completion, hover,
+  diagnostics, semantic tokens, and formatting.
+- `hone setup` command for editor integration (VS Code, Neovim, Vim).
+- `hone update` self-update flow for upgrading the installed binary.
+- `--watch` mode that re-runs affected tests on file changes.
+- JSON output format following the CTRF schema for CI integrations.
+
+[Unreleased]: https://github.com/captainsafia/hone/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/captainsafia/hone/releases/tag/v1.0.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<INSERT CONTACT EMAIL>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to Hone
+
+Thanks for your interest in improving Hone! This guide covers the basics
+of building, testing, and submitting changes.
+
+## Quick Start
+
+Hone is a Rust project built with Cargo. You will need a recent stable
+Rust toolchain (see `Cargo.toml` for the required edition).
+
+```sh
+# Build
+cargo build
+
+# Unit tests
+cargo test
+
+# Run the CLI locally
+cargo run -- tests/integration/*.hone
+
+# Optimized build
+cargo run --release -- tests/integration/*.hone
+```
+
+## Project Layout
+
+The Rust sources live under `src/`:
+
+- `parser/` — Lexer, parser, and AST for the `.hone` DSL.
+- `runner/` — Test executor, shell session, sentinel protocol, reporter.
+- `assertions/` — Implementations of stdout/stderr/exit code/timing/file assertions.
+- `lsp/` — Language Server implementation (completion, hover, diagnostics, etc.).
+- `setup/` — `hone setup` editor integrations (VS Code, Neovim, Vim).
+- `update/` — Self-update and update-check logic.
+- `watcher/` — `--watch` mode file watcher and scheduler.
+
+Integration tests written in the DSL live under `tests/integration/`,
+and end-to-end examples live under `examples/`.
+
+## Running the Test Suites
+
+Run the Rust unit tests with Cargo, and exercise the compiled binary
+against the `.hone` integration tests:
+
+```sh
+cargo test
+cargo run --release -- tests/integration/*.hone
+cargo run --release -- examples/*.hone
+```
+
+## Coding Style
+
+Follow the conventions documented in `AGENTS.md`, including the
+idiomatic Rust guidelines (naming, error propagation with `?`, preferring
+`&str` parameters, etc.). Before opening a pull request:
+
+```sh
+cargo fmt --check
+cargo clippy -- -D warnings
+```
+
+## Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) for all
+commit messages (e.g. `feat: add file size assertion`, `fix(parser): ...`,
+`docs: ...`). Do not add a `Co-Authored-By` trailer for AI assistants.
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a topic branch from `main`.
+2. Open the PR as a **draft** while you iterate. Link the related issue
+   in the description when one exists.
+3. Keep the change focused and include tests where practical.
+4. Ensure CI is green before marking the PR ready for review.
+
+## Reporting Bugs
+
+Please file bugs and feature requests through the project's
+[GitHub issue tracker](https://github.com/captainsafia/hone/issues),
+including a minimal `.hone` reproduction and the output of `hone --version`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported Versions
+
+The `1.0.x` series receives security fixes. Older pre-release builds are
+not supported; please upgrade to the latest `1.0.x` release before
+reporting an issue.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities by email to
+<INSERT SECURITY CONTACT>. Do **not** open a public GitHub issue for
+security problems — disclosing details publicly before a fix is
+available puts users at risk.
+
+We aim to acknowledge new reports within a few business days and target
+a coordinated disclosure window of **90 days** from the initial report.
+We will work with reporters to confirm the issue, prepare a fix, and
+agree on a public disclosure date.
+
+## Scope
+
+In scope:
+
+- The `hone` binary (CLI entry point and subcommands).
+- The DSL parser and runner.
+- The bundled Language Server (LSP).
+
+Out of scope:
+
+- Third-party shells invoked by Hone (bash, zsh, etc.).
+- User-authored test code executed by Hone.
+- The GitHub Action wrapper, which lives in its own repository and
+  follows its own security and release conventions.
+
+## Known Considerations
+
+- `hone update` currently downloads and runs an installer script over
+  HTTPS without verifying a release signature. Hardening this flow
+  (signature verification and pinned checksums) is tracked as a known
+  limitation; treat the self-update path accordingly in sensitive
+  environments.


### PR DESCRIPTION
Adds standard top-level community/project documentation files. Scope is intentionally limited to four new files at the repo root; no existing files are modified.

- `CHANGELOG.md` — Keep a Changelog 1.1.0 format with `[Unreleased]` and `[1.0.0] - 2026-05-18` sections covering the parser, runner, assertions, LSP, `hone setup`, `hone update`, `--watch`, and CTRF-style JSON output.
- `CONTRIBUTING.md` — short pragmatic guide (quick start, project layout, test commands, coding style pointing at `AGENTS.md`, Conventional Commits, PR/bug-report workflow).
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 verbatim with `<INSERT CONTACT EMAIL>` placeholder.
- `SECURITY.md` — supported versions, private email reporting via `<INSERT SECURITY CONTACT>`, 90-day disclosure window, scope, and a note that `hone update` runs an installer over HTTPS without signature verification.

### Verification

- `cargo fmt --check` passes (no Rust changes).
- `cargo clippy` skipped — no Rust source touched; also note this sandbox's stable Cargo (1.83.0) cannot resolve the full dependency tree because a transitive dep requires `edition2024`, so a full build would not succeed here regardless.

_Conversation: https://app.warp.dev/conversation/48a63e38-2b55-4715-a25a-73ab505e6ce0_

_This PR was generated with [Oz](https://warp.dev/oz)._
